### PR TITLE
docs: add CLAUDE.md and update README with development rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+GitHub ActionsでPythonのlintチェック（ruff, mypy）を実行するためのテンプレートリポジトリ。Python 3.10〜3.13をサポート。
+
+## 仮想環境
+
+特に指定がなければvenvを使用する：
+
+```bash
+python -m venv venv
+source venv/bin/activate
+```
+
+## コマンド
+
+```bash
+make init    # 依存関係のインストール
+make lint    # ruff check + ruff format --check + mypy
+make fmt     # ruff format + ruff check --fix（自動修正）
+make run     # main.py実行
+```
+
+## Lint設定
+
+- **ruff**: `pyproject.toml`で設定。行長79文字、E/F/Iルールを適用
+- **mypy**: 厳格な型チェック（`disallow_untyped_defs`, `disallow_untyped_calls`等）
+
+## 開発ルール
+
+### 型安全性
+
+- pydanticを使用してデータの型安全性を確保すること
+- 全ての関数・メソッドに型アノテーションを付与すること（mypyの`disallow_untyped_defs`で強制）
+
+### インポート
+
+- PEP 8に従う
+
+### ファイル構成
+
+- 1クラス1ファイルで管理すること
+- クラス名とファイル名を一致させること（例: `MyClass` → `my_class.py`）
+
+### オブジェクト指向設計
+
+- 単一責任の原則に従い、クラスを適切に分割すること
+- 継承よりコンポジションを優先すること
+
+### 定数管理
+
+- マジックナンバー/マジックストリングは使用禁止
+- 定数は`constants/`に定義して参照する
+
+### Enum定義
+
+- `auto()`は使用しない
+- タプルで`(code, display_name)`の形式で定義し、プロパティでアクセスできるようにする
+
+```python
+from enum import Enum
+
+class Status(Enum):
+    ACTIVE = (1, "有効")
+    INACTIVE = (0, "無効")
+
+    def __init__(self, code: int, display_name: str) -> None:
+        self._code = code
+        self._display_name = display_name
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+```
+
+### ディレクトリ構成
+
+`app/`ディレクトリをプロジェクトに応じて適切な名前に変更し、以下の構成で管理する：
+
+```text
+<project_name>/
+├── constants/    # Enum等の定数
+├── models/       # pydanticモデル
+├── services/     # ビジネスロジック
+└── exceptions/   # カスタム例外
+tests/            # テストコード
+```
+
+### Docstring
+
+- 公開API（publicな関数/クラス）には必ずDocstringを書く
+- Google styleで統一する
+
+### テスト
+
+- pytestを使用する
+- テストファイルは`tests/`に配置し、`test_*.py`の命名規則に従う
+
+### ログ出力
+
+- `print()`は使用禁止
+- `logging`モジュールを使用すること
+
+### コード変更時の必須作業
+
+- コード変更後は必ず `make lint` を実行してlintエラーがないことを確認すること
+- lintエラーがある場合は修正してからコミットすること

--- a/README.md
+++ b/README.md
@@ -8,3 +8,34 @@ The following linter results are detected by GitHub Actions.
 
 - ruff
 - mypy
+
+## Supported Python Versions
+
+- Python 3.10
+- Python 3.11
+- Python 3.12
+- Python 3.13
+
+## Setup
+
+```bash
+make init
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `make init` | Install dependencies |
+| `make lint` | Run lint checks (ruff check, ruff format --check, mypy) |
+| `make fmt` | Auto-format code (ruff format, ruff check --fix) |
+| `make run` | Run the application |
+
+## Development Rules
+
+- Use pydantic for type safety
+- One class per file
+- Follow object-oriented design principles
+- Always run `make lint` after code changes
+
+See [CLAUDE.md](CLAUDE.md) for details.

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,5 +1,39 @@
+"""Logging configuration module."""
+
+import logging
+import os
 from logging import Logger, getLogger
+from logging.handlers import TimedRotatingFileHandler
+
+LOG_DIRECTORY = "logs"
 
 
 def get_file_path_logger(module: str) -> Logger:
+    """Get logger from module name."""
     return getLogger(module.replace(".", "/"))
+
+
+def setup_logging(log_filename: str) -> None:
+    """
+    Configure logging.
+
+    Args:
+        log_filename: Log file name (e.g., "app.log")
+    """
+    os.makedirs(LOG_DIRECTORY, exist_ok=True)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        datefmt="%Y/%m/%d %H:%M:%S",
+        format="%(asctime)s [%(levelname)s] %(name)s:%(lineno)s %(message)s",
+        handlers=[
+            TimedRotatingFileHandler(
+                os.path.join(LOG_DIRECTORY, log_filename),
+                when="midnight",
+                backupCount=30,
+                interval=1,
+                encoding="utf-8",
+            ),
+            logging.StreamHandler(),
+        ],
+    )

--- a/main.py
+++ b/main.py
@@ -1,31 +1,7 @@
-import logging
-from logging import StreamHandler, basicConfig
-from logging.handlers import TimedRotatingFileHandler
-from os import makedirs
-
-from app.logger import get_file_path_logger
-
-LOG_DIRECTORY = "logs"
+from app.logger import get_file_path_logger, setup_logging
 
 logger = get_file_path_logger(__name__)
 
 if __name__ == "__main__":
-    makedirs(LOG_DIRECTORY, exist_ok=True)
-
-    basicConfig(
-        level=logging.INFO,
-        datefmt="%Y/%m/%d %H:%M:%S",
-        format="%(asctime)s [%(levelname)s] %(name)s:%(lineno)s %(message)s",
-        handlers=[
-            TimedRotatingFileHandler(
-                f"{LOG_DIRECTORY}/app.log",
-                when="midnight",
-                backupCount=30,
-                interval=1,
-                encoding="utf-8",
-            ),
-            StreamHandler(),
-        ],
-    )
-
+    setup_logging("app.log")
     logger.info("hello.")


### PR DESCRIPTION
CLAUDE.md:
- Project overview with Python 3.10-3.13 support
- Virtual environment (venv) usage rules
- Command list (make init/lint/fmt/run)
- Lint settings (ruff, mypy)
- Development rules:
  - Type safety: use pydantic, require type annotations
  - Import: follow PEP 8
  - File structure: one class per file
  - OOP design: single responsibility, prefer composition
  - Constants: no magic numbers, define in constants/
  - Enum: no auto(), use tuple (code, display_name) format
  - Directory structure: constants/models/services/exceptions/
  - Docstring: Google style
  - Testing: use pytest, place in tests/
  - Logging: no print(), use logging module
  - Code changes: run make lint before commit

README.md:
- Add Supported Python Versions section
- Add Setup instructions
- Add Commands table
- Add Development Rules summary
- Add link to CLAUDE.md

app/logger.py:
- Add setup_logging() function
- Add docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)